### PR TITLE
Remove special age treatment for Spain (Austurias)

### DIFF
--- a/src/Clumsy/AgeCheck/Ages/majority/alcohol/alcohol.php
+++ b/src/Clumsy/AgeCheck/Ages/majority/alcohol/alcohol.php
@@ -40,7 +40,6 @@ return array(
     'Sierra Leone'                       => 0,
     'Singapore'                          => 18,
     'Solomon Islands'                    => 21,
-    'Spain (Asturias)'                   => 16,
     'Sri Lanka'                          => 21,
     'Swaziland'                          => 18,
     'Tonga'                              => 21,

--- a/src/Clumsy/AgeCheck/Ages/majority/majority.php
+++ b/src/Clumsy/AgeCheck/Ages/majority/majority.php
@@ -125,7 +125,6 @@ return array(
     'Solomon Islands'                    => 18,
     'South Africa'                       => 18,
     'Spain'                              => 18,
-    'Spain (Asturias)'                   => 18,
     'Sri Lanka'                          => 18,
     'Swaziland'                          => 21,
     'Sweden'                             => 18,


### PR DESCRIPTION
From the [Wikipedia page on legal drinking ages](https://en.wikipedia.org/wiki/Legal_drinking_age):

> Asturias was the last autonomous community in Spain where the drinking age was increased to 18 (previously 16) on 1 May 2015.
